### PR TITLE
Improve time to empty example

### DIFF
--- a/NS_energyShield/examples/TimeToEmpty/TimeToEmpty.ino
+++ b/NS_energyShield/examples/TimeToEmpty/TimeToEmpty.ino
@@ -24,6 +24,7 @@ long lastTime;
 unsigned long TimeToEmpty;
 int Currents[CURRENTS_LEN];
 boolean charging;
+int latestPercent;
 
 void setup()
 {
@@ -35,6 +36,7 @@ void setup()
   for (int i=1; i < CURRENTS_LEN; ++i) Currents[i] = Currents[i-1];
 
   lastTime = millis(); 
+  latestPercent = eS.percent();
 }
 
 void loop()
@@ -56,9 +58,10 @@ void loop()
       Serial.print(TimeToEmpty/60); // Hours
       Serial.print(" hr ");
       Serial.print(TimeToEmpty%60); // Minutes
-      Serial.println(" min");
+      Serial.print(" min");
     }
-    else Serial.println("Charging!");
+    else Serial.print("Charging!");
+    Serial.print(" ("); Serial.print(latestPercent); Serial.println(" %)");
 
     delay(1); // Ensure that a ms passes, so it does not double print
   }
@@ -68,6 +71,9 @@ void TTE()
 {
   const int latestCurrent = eS.current();
   int AvgCurrent = 0;
+
+  // Update global
+  latestPercent = eS.percent();
 
   // Update charging state
   charging = (latestCurrent > 0);
@@ -86,5 +92,5 @@ void TTE()
   AvgCurrent /= CURRENTS_LEN;
 
   // Minutes until empty
-  TimeToEmpty = (unsigned long) BATTERY_CAPACITY*eS.percent()*60/AvgCurrent/200;
+  TimeToEmpty = (unsigned long) BATTERY_CAPACITY*latestPercent*60/AvgCurrent/200;
 }

--- a/NS_energyShield/examples/TimeToEmpty/TimeToEmpty.ino
+++ b/NS_energyShield/examples/TimeToEmpty/TimeToEmpty.ino
@@ -82,7 +82,7 @@ void TTE()
   Currents[0] = -latestCurrent;
 
   // Calculate AvgCurrent
-  for (int i=0; i < CURRENTS_LEN; ++i) AvgCurrent += Current[i];
+  for (int i=0; i < CURRENTS_LEN; ++i) AvgCurrent += Currents[i];
   AvgCurrent /= CURRENTS_LEN;
 
   // Minutes until empty

--- a/NS_energyShield/examples/TimeToEmpty/TimeToEmpty.ino
+++ b/NS_energyShield/examples/TimeToEmpty/TimeToEmpty.ino
@@ -15,25 +15,40 @@
 #include <Wire.h>
 
 #define BATTERY_CAPACITY 1200 // mAh
+#define CURRENTS_LEN 10 // array size
 
 NS_energyShield eS; // Create NS-energyShield object called "eS"
 
 // Global variables
-long lastTime = millis(); 
+long lastTime;
 unsigned long TimeToEmpty;
-int Current[10], AvgCurrent;
+int Currents[CURRENTS_LEN];
 boolean charging;
 
 void setup()
 {
   Serial.begin(9600);
+
+  // Initialize Currents array with initial value
+  const int latestCurrent = eS.current();
+  Currents[0] = (latestCurrent < 0) ? -latestCurrent : 0;
+  for (int i=1; i < CURRENTS_LEN; ++i) Currents[i] = Currents[i-1];
+
+  lastTime = millis(); 
 }
 
 void loop()
 {
-  if (millis() > lastTime + 100) TTE(); // Run TTE every 100 ms
+  const unsigned long ts = millis();
 
-  if (millis()%5000 == 0) // Print results every 5 seconds
+  // Note: if lastTime < ts this means it wrapped, and
+  //       in such case, we treat it as if 100ms went by
+  if (ts > lastTime + 100 || lastTime < ts) {
+    TTE(); // Run TTE every 100 ms
+    lastTime = ts;
+  }
+
+  if (ts%5000 == 0) // Print results every 5 seconds
   {
     if (!charging) 
     {
@@ -43,7 +58,7 @@ void loop()
       Serial.print(TimeToEmpty%60); // Minutes
       Serial.println(" min");
     }
-    else Serial.print("Charging!");
+    else Serial.println("Charging!");
 
     delay(1); // Ensure that a ms passes, so it does not double print
   }
@@ -51,29 +66,25 @@ void loop()
 
 void TTE()
 {
-  for(int i=9;i>0;i--) Current[i] = Current [i-1];
-  Current[0] = eS.current();
+  const int latestCurrent = eS.current();
+  int AvgCurrent = 0;
 
-  for (int i=9;i>=0;i--)
-  {
-    if (Current[i] < 0)
-    {
-      Current[i] = -Current[i];
-      charging = 0;
-    }
-    else
-    {
-      charging = 1;
-    }
-  }
+  // Update charging state
+  charging = (latestCurrent > 0);
 
-  // Check that energyShield is not charging
-  for(int i=0;i<10;i++) AvgCurrent += Current[i];
-  AvgCurrent /= 10;
+  // If we are currently charging or not drawing any
+  // current, then there is nothing to do in regards to
+  // TimeToEmpty calculation
+  if (charging || latestCurrent == 0) return;
 
-  TimeToEmpty = (unsigned long) BATTERY_CAPACITY*eS.percent()*60/AvgCurrent/200; // Minutes until empty
+  // Shift Currents array by 1 and add new current value to index 0
+  for (int i=1; i < CURRENTS_LEN; ++i) Currents[i] = Currents[i-1];
+  Currents[0] = -latestCurrent;
 
-  lastTime = millis();
+  // Calculate AvgCurrent
+  for (int i=0; i < CURRENTS_LEN; ++i) AvgCurrent += Current[i];
+  AvgCurrent /= CURRENTS_LEN;
+
+  // Minutes until empty
+  TimeToEmpty = (unsigned long) BATTERY_CAPACITY*eS.percent()*60/AvgCurrent/200;
 }
-
-


### PR DESCRIPTION
- make array for storing average variable lenght
- work properly if millis() value wraps when comparing with lastTime
- avoid redundant call to millis()
- fix logic to determine if charging is taking place
